### PR TITLE
Optimize the performance of character comparison

### DIFF
--- a/is.go
+++ b/is.go
@@ -26,7 +26,7 @@ func InRange(value, left, right float64) bool {
 // and that it is not in the first or last character of the string
 // https://en.wikipedia.org/wiki/Email_address#Valid_email_addresses
 func Email(s string) bool {
-	if !strings.Contains(s, "@") || string(s[0]) == "@" || string(s[len(s)-1]) == "@" {
+	if !strings.Contains(s, "@") || s[0] == '@' || s[len(s)-1] == '@' {
 		return false
 	}
 	return true

--- a/is_test.go
+++ b/is_test.go
@@ -557,6 +557,36 @@ func TestEmail(t *testing.T) {
 	}
 }
 
+func BenchmarkEmail(b *testing.B) {
+	var tests = []struct {
+		param    string
+		expected bool
+	}{
+		{``, false},
+		{`foo@bar.com`, true},
+		{`x@x.x`, true},
+		{`foo@bar.com.au`, true},
+		{`foo+bar@bar.com`, true},
+		{`foo@bar.coffee`, true},
+		{`foo@bar.中文网`, true},
+		{`invalidemail@`, false},
+		{`invalid.com`, false},
+		{`@invalid.com`, false},
+		{`test|123@m端ller.com`, true},
+		{`hans@m端ller.com`, true},
+		{`hans.m端ller@test.com`, true},
+		{`NathAn.daVIeS@DomaIn.cOM`, true},
+		{`NATHAN.DAVIES@DOMAIN.CO.UK`, true},
+		{`very.(),:;<>[]".VERY."very@\ "very".unusual@strange.example.com`, true},
+	}
+
+	for i := 0; i < 1000000; i++ {
+		for _, test := range tests {
+			Email(test.param)
+		}
+	}
+}
+
 func ExampleEmail() {
 	fmt.Println(Email("jhon@example.com"))
 	fmt.Println(Email("invalid.com"))


### PR DESCRIPTION
change the char comparison of Email, and add the benchmark:

Change before:
monkboy@monkboy:~/work/go/src/github.com/MonkSunBoy/is$ go test -bench .
BenchmarkEmail-4   	2000000000	         0.34 ns/op
PASS
ok  	github.com/MonkSunBoy/is	19.904s
monkboy@monkboy:~/work/go/src/github.com/MonkSunBoy/is$ go test -bench .
BenchmarkEmail-4   	2000000000	         0.33 ns/op
PASS
ok  	github.com/MonkSunBoy/is	19.276s
monkboy@monkboy:~/work/go/src/github.com/MonkSunBoy/is$ go test -bench .
BenchmarkEmail-4   	2000000000	         0.33 ns/op
PASS
ok  	github.com/MonkSunBoy/is	20.348s

Change after:
monkboy@monkboy:~/work/go/src/github.com/MonkSunBoy/is$ go test -bench .
BenchmarkEmail-4   	2000000000	         0.12 ns/op
PASS
ok  	github.com/MonkSunBoy/is	3.925s
monkboy@monkboy:~/work/go/src/github.com/MonkSunBoy/is$ go test -bench .
BenchmarkEmail-4   	2000000000	         0.13 ns/op
PASS
ok  	github.com/MonkSunBoy/is	3.940s
monkboy@monkboy:~/work/go/src/github.com/MonkSunBoy/is$ go test -bench .
BenchmarkEmail-4   	1000000000	         0.26 ns/op
PASS
ok  	github.com/MonkSunBoy/is	3.402s