### PR TITLE
much much faster uuid checks

### DIFF
--- a/is.go
+++ b/is.go
@@ -211,22 +211,43 @@ func ByteLength(str string, min, max int) bool {
 
 // UUIDv3 check if the string is a UUID version 3.
 func UUIDv3(str string) bool {
-	return rxUUID3.MatchString(str)
+	return UUID(str) && str[14] == '3'
 }
 
 // UUIDv4 check if the string is a UUID version 4.
 func UUIDv4(str string) bool {
-	return rxUUID4.MatchString(str)
+	return UUID(str) &&
+		str[14] == '4' &&
+		(str[19] == '8' || str[19] == '9' || str[19] == 'a' || str[19] == 'b')
 }
 
 // UUIDv5 check if the string is a UUID version 5.
 func UUIDv5(str string) bool {
-	return rxUUID5.MatchString(str)
+	return UUID(str) &&
+		str[14] == '5' &&
+		(str[19] == '8' || str[19] == '9' || str[19] == 'a' || str[19] == 'b')
 }
 
 // UUID check if the string is a UUID (version 3, 4 or 5).
 func UUID(str string) bool {
-	return rxUUID.MatchString(str)
+	if len(str) != 36 {
+		return false
+	}
+
+	for i, c := range str {
+		if i == 8 || i == 13 || i == 18 || i == 23 {
+			if c != '-' {
+				return false
+			}
+			continue
+		}
+
+		if ('f' < c || c < 'a') && ('9' < c || c < '0') {
+			return false
+		}
+	}
+
+	return true
 }
 
 // CreditCard check if the string is a credit card.

--- a/patterns.go
+++ b/patterns.go
@@ -269,10 +269,6 @@ const (
 	pCreditCard string = "^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\d{3})\\d{11})$"
 	pISBN10     string = "^(?:[0-9]{9}X|[0-9]{10})$"
 	pISBN13     string = "^(?:[0-9]{13})$"
-	pUUID3      string = "^[0-9a-f]{8}-[0-9a-f]{4}-3[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$"
-	pUUID4      string = "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
-	pUUID5      string = "^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
-	pUUID       string = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
 	// pAlpha       string = "^[a-zA-Z]+$"
 	// pAlphanumeric string = "^[a-zA-Z0-9]+$"
 	// pNumeric      string = "^[-+]?[0-9]+$"
@@ -315,10 +311,6 @@ var (
 	rxCreditCard = regexp.MustCompile(pCreditCard)
 	rxISBN10     = regexp.MustCompile(pISBN10)
 	rxISBN13     = regexp.MustCompile(pISBN13)
-	rxUUID3      = regexp.MustCompile(pUUID3)
-	rxUUID4      = regexp.MustCompile(pUUID4)
-	rxUUID5      = regexp.MustCompile(pUUID5)
-	rxUUID       = regexp.MustCompile(pUUID)
 	// rxAlpha          = regexp.MustCompile(Alpha)
 	// rxAlphanumeric   = regexp.MustCompile(Alphanumeric)
 	// rxNumeric        = regexp.MustCompile(Numeric)


### PR DESCRIPTION
This patch must significantly improve UUIDs check.

There are benchmarks:
```bash
$ go test -bench=.
testing: warning: no tests to run
BenchmarkIsUUIDSimple-4    	10000000	       201 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsUUID3Simple-4   	10000000	       205 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsUUID4Simple-4   	10000000	       206 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsUUID5Simple-4   	10000000	       201 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsUUIDRx-4        	 1000000	      1020 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsUUIDv3Rx-4      	 1000000	      1102 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsUUIDv4Rx-4      	 1000000	      1100 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsUUIDv5Rx-4      	 1000000	      1042 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/bbrodriges/bench	13.280s
```