### PR TITLE
further speed up

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -1,0 +1,127 @@
+package is
+
+import (
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+type benchmarkCase struct {
+	function func(string) bool
+	caseName string
+	param    string
+}
+
+var (
+	benchmarkFuncs = []benchmarkCase{
+		// Alpha
+		benchmarkCase{Alpha, "Empty", ""},
+		benchmarkCase{Alpha, "Space", " "},
+		benchmarkCase{Alpha, "False", "abc!!!"},
+		benchmarkCase{Alpha, "True", "abc"},
+		//UTFLetter
+		benchmarkCase{UTFLetter, "Empty", ""},
+		benchmarkCase{UTFLetter, "Space", " "},
+		benchmarkCase{UTFLetter, "False", "\u0026"}, //UTF-8(ASCII): &
+		benchmarkCase{UTFLetter, "True", "abc"},
+		// Alphanumeric
+		benchmarkCase{Alphanumeric, "Empty", ""},
+		benchmarkCase{Alphanumeric, "Space", " "},
+		benchmarkCase{Alphanumeric, "False", "\u0026"}, //UTF-8(ASCII): &
+		benchmarkCase{Alphanumeric, "True", "abc123"},
+		// UTFLetterNumeric
+		benchmarkCase{UTFLetterNumeric, "Empty", ""},
+		benchmarkCase{UTFLetterNumeric, "Space", " "},
+		benchmarkCase{UTFLetterNumeric, "False", "abc!!!"},
+		benchmarkCase{UTFLetterNumeric, "True", "abc1"},
+		// Numeric
+		benchmarkCase{Numeric, "Empty", ""},
+		benchmarkCase{Numeric, "Space", " "},
+		benchmarkCase{Numeric, "False", "abc!!!"},
+		benchmarkCase{Numeric, "True", "0123"},
+		// UTFNumeric
+		benchmarkCase{UTFNumeric, "Empty", ""},
+		benchmarkCase{UTFNumeric, "Space", " "},
+		benchmarkCase{UTFNumeric, "False", "abc!!!"},
+		benchmarkCase{UTFNumeric, "True", "\u0030"}, //UTF-8(ASCII): 0
+		// UTFDigit
+		benchmarkCase{UTFDigit, "Empty", ""},
+		benchmarkCase{UTFDigit, "Space", " "},
+		benchmarkCase{UTFDigit, "False", "abc!!!"},
+		benchmarkCase{UTFDigit, "True", "\u0030"}, //UTF-8(ASCII): 0
+		// LowerCase
+		benchmarkCase{LowerCase, "Empty", ""},
+		benchmarkCase{LowerCase, "Space", " "},
+		benchmarkCase{LowerCase, "False", "ABC"},
+		benchmarkCase{LowerCase, "True", "abc"},
+		// UpperCase
+		benchmarkCase{UpperCase, "Empty", ""},
+		benchmarkCase{UpperCase, "Space", " "},
+		benchmarkCase{UpperCase, "False", "abc"},
+		benchmarkCase{UpperCase, "True", "ABC"},
+		// Int
+		benchmarkCase{Int, "Empty", ""},
+		benchmarkCase{Int, "Space", " "},
+		benchmarkCase{Int, "False", "abc"},
+		benchmarkCase{Int, "True", "000"},
+		// Email
+		benchmarkCase{Email, "Empty", ""},
+		benchmarkCase{Email, "Space", " "},
+		benchmarkCase{Email, "False", "@invalid.com"},
+		benchmarkCase{Email, "True", "foo@bar.com"},
+		// URL
+		benchmarkCase{URL, "Empty", ""},
+		benchmarkCase{URL, "Space", " "},
+		benchmarkCase{URL, "False", "./rel/test/dir"},
+		benchmarkCase{URL, "True", "http://foobar.org/"},
+		// RequestURL
+		benchmarkCase{RequestURL, "Empty", ""},
+		benchmarkCase{RequestURL, "Space", " "},
+		benchmarkCase{RequestURL, "False", "invalid."},
+		benchmarkCase{RequestURL, "True", "http://foobar.org/"},
+		// RequestURI
+		benchmarkCase{RequestURI, "Empty", ""},
+		benchmarkCase{RequestURI, "Space", " "},
+		benchmarkCase{RequestURI, "False", "invalid."},
+		benchmarkCase{RequestURI, "True", "http://foobar.org/"},
+		// Float
+		benchmarkCase{Float, "Empty", ""},
+		benchmarkCase{Float, "Space", " "},
+		benchmarkCase{Float, "False", "+1f"},
+		benchmarkCase{Float, "True", "123.123"},
+		// Hexadecimal
+		benchmarkCase{Hexadecimal, "Empty", ""},
+		benchmarkCase{Hexadecimal, "Space", " "},
+		benchmarkCase{Hexadecimal, "False", ".."},
+		benchmarkCase{Hexadecimal, "True", "deadBEEF"},
+		// Hexcolor
+		benchmarkCase{Hexcolor, "Empty", ""},
+		benchmarkCase{Hexcolor, "Space", " "},
+		benchmarkCase{Hexcolor, "False", "#ff12FG"},
+		benchmarkCase{Hexcolor, "True", "#f00"},
+		// RGBcolor
+		benchmarkCase{RGBcolor, "Empty", ""},
+		benchmarkCase{RGBcolor, "Space", " "},
+		benchmarkCase{RGBcolor, "False", "rgba(0,31,255)"},
+		benchmarkCase{RGBcolor, "True", "rgb(0,31,255)"},
+	}
+)
+
+func getFuncName(f interface{}) string {
+	n := runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
+	return filepath.Base(n)
+}
+
+func Benchmark(b *testing.B) {
+	for _, bencCase := range benchmarkFuncs {
+		name := getFuncName(bencCase.function) + "." + bencCase.caseName
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				bencCase.function(bencCase.param)
+			}
+		})
+	}
+}

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package is
 
 import (

--- a/is.go
+++ b/is.go
@@ -164,12 +164,52 @@ func Hexadecimal(str string) bool {
 
 // Hexcolor check if the string is a hexadecimal color.
 func Hexcolor(str string) bool {
-	return rxHexcolor.MatchString(str)
+	if str == "" {
+		return false
+	}
+
+	if str[0] == '#' {
+		str = str[1:]
+	}
+
+	if len(str) != 3 && len(str) != 6 {
+		return false
+	}
+
+	for _, c := range str {
+		if ('F' < c || c < 'A') && ('f' < c || c < 'a') && ('9' < c || c < '0') {
+			return false
+		}
+	}
+
+	return true
 }
 
 // RGBcolor check if the string is a valid RGB color in form rgb(RRR, GGG, BBB).
 func RGBcolor(str string) bool {
-	return rxRGBcolor.MatchString(str)
+	if str == "" || len(str) < 10 {
+		return false
+	}
+
+	if str[0:4] != "rgb(" || str[len(str)-1] != ')' {
+		return false
+	}
+
+	str = str[4 : len(str)-1]
+	str = strings.TrimSpace(str)
+
+	for _, p := range strings.Split(str, ",") {
+		if len(p) > 1 && p[0] == '0' {
+			return false
+		}
+
+		p = strings.TrimSpace(p)
+		if i, e := strconv.Atoi(p); (255 < i || i < 0) || e != nil {
+			return false
+		}
+	}
+
+	return true
 }
 
 // LowerCase check if the string is lowercase. Empty string is valid.
@@ -406,8 +446,8 @@ func Base64(s string) bool {
 // FilePath check is a string is Win or Unix file path and returns it's type.
 func FilePath(str string) (bool, int) {
 	if rxWinPath.MatchString(str) {
-		//check windows path limit see:
-		//  http://msdn.microsoft.com/en-us/library/aa365247(VS.85).aspx#maxpath
+		// check windows path limit see:
+		// http://msdn.microsoft.com/en-us/library/aa365247(VS.85).aspx#maxpath
 		if len(str[3:]) > 32767 {
 			return false, Win
 		}
@@ -506,17 +546,53 @@ func MAC(str string) bool {
 
 // MongoID check if the string is a valid hex-encoded representation of a MongoDB ObjectId.
 func MongoID(str string) bool {
-	return rxMongoID.MatchString(str)
+	if str == "" || len(str) != 24 {
+		return false
+	}
+
+	for _, c := range str {
+		if ('F' < c || c < 'A') && ('f' < c || c < 'a') && ('9' < c || c < '0') {
+			return false
+		}
+	}
+
+	return true
 }
 
 // Latitude check if a string is valid latitude.
 func Latitude(str string) bool {
-	return rxLatitude.MatchString(str)
+	if str == "" {
+		return false
+	}
+
+	f, err := strconv.ParseFloat(str, 64)
+	if err != nil {
+		return false
+	}
+
+	if 90.0 < f || f < -90.0 {
+		return false
+	}
+
+	return true
 }
 
 // Longitude check if a string is valid longitude.
 func Longitude(str string) bool {
-	return rxLongitude.MatchString(str)
+	if str == "" {
+		return false
+	}
+
+	f, err := strconv.ParseFloat(str, 64)
+	if err != nil {
+		return false
+	}
+
+	if 180.0 < f || f < -180.0 {
+		return false
+	}
+
+	return true
 }
 
 // SSN will validate the given string as a U.S. Social Security Number

--- a/is_test.go
+++ b/is_test.go
@@ -557,36 +557,6 @@ func TestEmail(t *testing.T) {
 	}
 }
 
-func BenchmarkEmail(b *testing.B) {
-	var tests = []struct {
-		param    string
-		expected bool
-	}{
-		{``, false},
-		{`foo@bar.com`, true},
-		{`x@x.x`, true},
-		{`foo@bar.com.au`, true},
-		{`foo+bar@bar.com`, true},
-		{`foo@bar.coffee`, true},
-		{`foo@bar.中文网`, true},
-		{`invalidemail@`, false},
-		{`invalid.com`, false},
-		{`@invalid.com`, false},
-		{`test|123@m端ller.com`, true},
-		{`hans@m端ller.com`, true},
-		{`hans.m端ller@test.com`, true},
-		{`NathAn.daVIeS@DomaIn.cOM`, true},
-		{`NATHAN.DAVIES@DOMAIN.CO.UK`, true},
-		{`very.(),:;<>[]".VERY."very@\ "very".unusual@strange.example.com`, true},
-	}
-
-	for i := 0; i < 1000000; i++ {
-		for _, test := range tests {
-			Email(test.param)
-		}
-	}
-}
-
 func ExampleEmail() {
 	fmt.Println(Email("jhon@example.com"))
 	fmt.Println(Email("invalid.com"))

--- a/patterns.go
+++ b/patterns.go
@@ -275,24 +275,19 @@ const (
 	// pInt         string = "^(?:[-+]?(?:0|[1-9][0-9]*))$"
 	// pFloat       string = "^(?:[-+]?(?:[0-9]+))?(?:\\.[0-9]*)?(?:[eE][\\+\\-]?(?:[0-9]+))?$"
 	// pHexadecimal string = "^[0-9a-fA-F]+$"
-	pMongoID  string = "^[0-9a-fA-F]{24}$"
-	pHexcolor string = "^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$"
-	pRGBcolor string = "^rgb\\(\\s*(0|[1-9]\\d?|1\\d\\d?|2[0-4]\\d|25[0-5])\\s*,\\s*(0|[1-9]\\d?|1\\d\\d?|2[0-4]\\d|25[0-5])\\s*,\\s*(0|[1-9]\\d?|1\\d\\d?|2[0-4]\\d|25[0-5])\\s*\\)$"
 	// pASCII       string = "^[\x00-\x7F]+$"
 	// pMultibyte string = "[^\x00-\x7F]"
 	pFullWidth string = "[^\u0020-\u007E\uFF61-\uFF9F\uFFA0-\uFFDC\uFFE8-\uFFEE0-9a-zA-Z]"
 	pHalfWidth string = "[\u0020-\u007E\uFF61-\uFF9F\uFFA0-\uFFDC\uFFE8-\uFFEE0-9a-zA-Z]"
 	// pBase64    string = "^(?:[A-Za-z0-9+\\/]{4})*(?:[A-Za-z0-9+\\/]{2}==|[A-Za-z0-9+\\/]{3}=|[A-Za-z0-9+\\/]{4})$"
 	// pPrintableASCII string = "^[\x20-\x7E]+$"
-	pDataURI   string = "^data:.+\\/(.+);base64$"
-	pLatitude  string = "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?)$"
-	pLongitude string = "^[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
-	pDNSName   string = `^([a-zA-Z0-9]{1}[a-zA-Z0-9_-]{1,62}){1}(.[a-zA-Z0-9]{1}[a-zA-Z0-9_-]{1,62})*$`
-	pURL       string = `^((ftp|https?):\/\/)?(\S+(:\S*)?@)?((([1-9]\d?|1\d\d|2[01]\d|22[0-3])(\.(1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.([0-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(([a-zA-Z0-9]+([-\.][a-zA-Z0-9]+)*)|((www\.)?))?(([a-z\x{00a1}-\x{ffff}0-9]+-?-?)*[a-z\x{00a1}-\x{ffff}0-9]+)(?:\.([a-z\x{00a1}-\x{ffff}]{2,}))?))(:(\d{1,5}))?((\/|\?|#)[^\s]*)?$`
-	pSSN       string = `^\d{3}[- ]?\d{2}[- ]?\d{4}$`
-	pWinPath   string = `^[a-zA-Z]:\\(?:[^\\/:*?"<>|\r\n]+\\)*[^\\/:*?"<>|\r\n]*$`
-	pUnixPath  string = `^((?:\/[a-zA-Z0-9\.\:]+(?:_[a-zA-Z0-9\:\.]+)*(?:\-[\:a-zA-Z0-9\.]+)*)+\/?)$`
-	pSemver    string = "^v?(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(-(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\\+[0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*)?$"
+	pDataURI  string = "^data:.+\\/(.+);base64$"
+	pDNSName  string = `^([a-zA-Z0-9]{1}[a-zA-Z0-9_-]{1,62}){1}(.[a-zA-Z0-9]{1}[a-zA-Z0-9_-]{1,62})*$`
+	pURL      string = `^((ftp|https?):\/\/)?(\S+(:\S*)?@)?((([1-9]\d?|1\d\d|2[01]\d|22[0-3])(\.(1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.([0-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(([a-zA-Z0-9]+([-\.][a-zA-Z0-9]+)*)|((www\.)?))?(([a-z\x{00a1}-\x{ffff}0-9]+-?-?)*[a-z\x{00a1}-\x{ffff}0-9]+)(?:\.([a-z\x{00a1}-\x{ffff}]{2,}))?))(:(\d{1,5}))?((\/|\?|#)[^\s]*)?$`
+	pSSN      string = `^\d{3}[- ]?\d{2}[- ]?\d{4}$`
+	pWinPath  string = `^[a-zA-Z]:\\(?:[^\\/:*?"<>|\r\n]+\\)*[^\\/:*?"<>|\r\n]*$`
+	pUnixPath string = `^((?:\/[a-zA-Z0-9\.\:]+(?:_[a-zA-Z0-9\:\.]+)*(?:\-[\:a-zA-Z0-9\.]+)*)+\/?)$`
+	pSemver   string = "^v?(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(-(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\\+[0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*)?$"
 )
 
 // Used by IsFilePath func
@@ -317,22 +312,17 @@ var (
 	// rxInt         = regexp.MustCompile(pInt)
 	// rxFloat       = regexp.MustCompile(pFloat)
 	// rxHexadecimal = regexp.MustCompile(pHexadecimal)
-	rxMongoID  = regexp.MustCompile(pMongoID)
-	rxHexcolor = regexp.MustCompile(pHexcolor)
-	rxRGBcolor = regexp.MustCompile(pRGBcolor)
 	// rxASCII          = regexp.MustCompile(ASCII)
 	// rxPrintableASCII = regexp.MustCompile(PrintableASCII)
 	// rxMultibyte = regexp.MustCompile(pMultibyte)
 	rxFullWidth = regexp.MustCompile(pFullWidth)
 	rxHalfWidth = regexp.MustCompile(pHalfWidth)
 	// rxBase64         = regexp.MustCompile(Base64)
-	rxDataURI   = regexp.MustCompile(pDataURI)
-	rxLatitude  = regexp.MustCompile(pLatitude)
-	rxLongitude = regexp.MustCompile(pLongitude)
-	rxDNSName   = regexp.MustCompile(pDNSName)
-	rxURL       = regexp.MustCompile(pURL)
-	rxSSN       = regexp.MustCompile(pSSN)
-	rxWinPath   = regexp.MustCompile(pWinPath)
-	rxUnixPath  = regexp.MustCompile(pUnixPath)
-	rxSemver    = regexp.MustCompile(pSemver)
+	rxDataURI  = regexp.MustCompile(pDataURI)
+	rxDNSName  = regexp.MustCompile(pDNSName)
+	rxURL      = regexp.MustCompile(pURL)
+	rxSSN      = regexp.MustCompile(pSSN)
+	rxWinPath  = regexp.MustCompile(pWinPath)
+	rxUnixPath = regexp.MustCompile(pUnixPath)
+	rxSemver   = regexp.MustCompile(pSemver)
 )


### PR DESCRIPTION
I've rewrote some more functions from regexps:

- Hexcolor
- RGBColor
- MongoID
- Latitude
- Longitude

Here are benchmarks:

```bash
$ go test -bench=.
testing: warning: no tests to run
BenchmarkOldHexcolor-4    	 3000000	       418 ns/op	       0 B/op	       0 allocs/op
BenchmarkNewHexcolor-4    	50000000	        29.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkOldRGBcolor-4    	 1000000	      1233 ns/op	       0 B/op	       0 allocs/op
BenchmarkNewRGBcolor-4    	 5000000	       356 ns/op	      48 B/op	       1 allocs/op
BenchmarkOldMongoID-4     	 2000000	       712 ns/op	       0 B/op	       0 allocs/op
BenchmarkNewMongoID-4     	10000000	       146 ns/op	       0 B/op	       0 allocs/op
BenchmarkOldLatitude-4    	 3000000	       484 ns/op	       0 B/op	       0 allocs/op
BenchmarkNewLatitude-4    	30000000	        50.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkOldLongitude-4   	 3000000	       576 ns/op	       0 B/op	       0 allocs/op
BenchmarkNewLongitude-4   	30000000	        52.0 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/bbrodriges/bench	17.763s
```

The only thing that bothers me is that little nasty allocation in new version of RGBColor.